### PR TITLE
#7 - Fix nlhomann/json import

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.configureOnOpen": false
+}

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ TEST_CPP_FILES := $(wildcard test/src/*.cpp)
 TEST_OBJ_FILES := $(TEST_CPP_FILES:.cpp=.o)
 
 # Includes
-INCLUDES := -Ithird-party/json/single_include/ \
+INCLUDES := \
+	-Ithird-party/json/single_include/ \
 	-Ithird-party/catch2/single_include
 
 # Generic compiling flags
@@ -43,15 +44,17 @@ clean:
 distclean: clean
 
 check:
-	@if which cppcheck; then \
-	    echo "OK"; \
-        cppcheck --enable=all --quiet --inconclusive \
+	@if `which cppcheck > /dev/null`; then \
+		echo "Checking code with cppcheck"; \
+		cppcheck --enable=all --quiet --inconclusive \
 			--std=$(CPP_LANGUAGE_VERSION) \
-			--suppress=*:*catch.hpp \
+			--suppress=*:third-party/* \
+			--suppress=toomanyconfigs \
+			--suppress=missingIncludeSystem \
 			$(TEST_NAME).cpp $(TEST_CPP_FILES) $(LIBRARY_CPP_FILES); \
 	else \
-      echo "cppcheck not installed"; \
-      false; \
+		echo "cppcheck not installed"; \
+		false; \
 	fi
 
 test: all

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "../third-party/json/single_include/nlohmann/json.hpp"

--- a/src/mustache-light.cpp
+++ b/src/mustache-light.cpp
@@ -40,21 +40,23 @@ using json = nlohmann::json;
 
 #include <iostream>
 #include <vector>
-#include <codecvt>
-
-// Used for readFile
-#include <fstream>
-#include <string>
-#include <sstream>
+using std::vector;
+#include <map>
+using std::map;
 
 #include <algorithm>
 #include <functional>
 #include <cctype>
-#include <locale>
 
-using std::vector;
+#include <string>
 using std::string;
-using std::map;
+
+// Used for readFile
+#include <fstream>
+#include <sstream>
+
+
+
 
 namespace mustache {
 
@@ -832,13 +834,13 @@ json Mustache::searchVariableInContext(const string& key) {
                 return "null"_json;
         }
 
-        std::string::size_type start;
-        std::string::size_type stop;
-        std::string::size_type index = std::string::npos;
+        string::size_type start;
+        string::size_type stop;
+        string::size_type index = string::npos;
         string newKey = key;
 
-        if ((start = key.find_first_of("[")) != std::string::npos) {
-                if ((stop = key.find_first_of("]")) == std::string::npos) {
+        if ((start = key.find_first_of("[")) != string::npos) {
+                if ((stop = key.find_first_of("]")) == string::npos) {
                         error("Missing ] in array selection");
                 }
                 if (start + 1 == stop) {
@@ -855,7 +857,7 @@ json Mustache::searchVariableInContext(const string& key) {
         if (it == top.end()) {
                 LOG_END("NOT FOUND:");
                 throw std::invalid_argument("Variable " + key + " not found");
-        } else if (index == std::string::npos) {
+        } else if (index == string::npos) {
                 LOG_END("NORMAL USE *it:");
                 json value = *it;
                 return value;
@@ -961,19 +963,23 @@ void Mustache::dumpTokens() {
 
 // trim from start
 inline string& Mustache::ltrim(string& s) {
-        s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
-        return s;
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }));
+    return s;
 }
 
 // trim from end
 inline std::string& Mustache::rtrim(string& s) {
-        s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
-        return s;
+   s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }).base(), s.end());
+    return s;
 }
 
 // trim from both ends
 inline string& Mustache::trim(string& s) {
-        return ltrim(rtrim(s));
+    return ltrim(rtrim(s));
 }
 
 void Mustache::htmlEscape(string& data)

--- a/src/mustache-light.hpp
+++ b/src/mustache-light.hpp
@@ -33,8 +33,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef SRC_MUSTACHE_LIGHT_HPP_
-#define SRC_MUSTACHE_LIGHT_HPP_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -42,7 +41,7 @@
 #include <stack>
 #include <stdexcept>
 
-#include <nlohmann/json.hpp>
+#include "json.hpp"
 
 namespace mustache {
 
@@ -317,7 +316,5 @@ class Mustache {
 };
 
 } // namespace mustache
-
-#endif  // SRC_MUSTACHE_LIGHT_HPP_
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Use local imports in order to avoid include errors.